### PR TITLE
Fix tag filtering: support hierarchical tags and normalize # prefix

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -68,7 +68,13 @@ function checkFilterForFile(
       const tags = getAllTags(
         get(appCache).getFileCache(file) as CachedMetadata
       );
-      if (tags?.includes(val)) return true;
+      // Normalize # prefix for consistent comparison
+      const normalizedVal = val.replace(/^#/, "");
+      if (tags?.some(tag => {
+        const normalizedTag = tag.replace(/^#/, "");
+        // Support exact match and hierarchical tags (e.g., #project matches #project/subtask)
+        return normalizedTag === normalizedVal || normalizedTag.startsWith(normalizedVal + "/");
+      })) return true;
       break;
     }
 


### PR DESCRIPTION
## Problem

Tag filtering doesn't work correctly in two ways:

1. **# prefix mismatch**: `getAllTags()` and filter values have inconsistent `#` handling, causing exact matches to fail silently (returns 0 results even when files exist with that tag)

2. **No hierarchical support**: `tag: #parent` doesn't match files tagged `#parent/child`, which is a common Obsidian pattern for organizing nested tags

## Solution

- Normalize both filter value and tags by stripping `#` prefix before comparison
- Use `startsWith()` to support hierarchical tag matching

## Changes

**File:** `src/store.ts` - `checkFilterForFile()` function

```typescript
// Before
if (tags?.includes(val)) return true;

// After  
const normalizedVal = val.replace(/^#/, "");
if (tags?.some(tag => {
  const normalizedTag = tag.replace(/^#/, "");
  return normalizedTag === normalizedVal || normalizedTag.startsWith(normalizedVal + "/");
})) return true;
```

## Testing

- `tag: #parent/child` → matches exact tag
- `tag: #parent` → matches all `#parent/*` nested tags
- `tag: parent` (without #) → also works now

This is a backwards-compatible change that makes tag filtering work as users would intuitively expect.